### PR TITLE
four punctuation and case changes

### DIFF
--- a/src/id/inspect0.a
+++ b/src/id/inspect0.a
@@ -187,7 +187,7 @@ IDBootloader
          sta   gIsProDOS
          beq   .useuniv   ; always branches
 ;
-;Apple Pascal (all versions)
+; Apple Pascal (all versions)
 ;
 +        jsr   IDPascal
          bcs   +

--- a/src/patchers/d5d5f7.a
+++ b/src/patchers/d5d5f7.a
@@ -4,7 +4,7 @@
 ; involving $D5 and $F7 as delimiters
 ;
 ; Ace Detective
-; Cat 'N Mouse
+; Cat 'n Mouse
 ; Cotton Tales
 ; Dyno-Quest
 ; Easy Street

--- a/src/patchers/memory.config.a
+++ b/src/patchers/memory.config.a
@@ -1,6 +1,6 @@
 ;-------------------------------
 ; #MEMORYCONFIG
-; modified PRODOS launches MEMORY.CONFIG
+; modified ProDOS launches MEMORY.CONFIG
 ; as startup program, which executes a
 ; protection check before launching the
 ; real startup program

--- a/src/patchers/sierra.a
+++ b/src/patchers/sierra.a
@@ -188,7 +188,7 @@
          !byte $20,$85,$1E ;JSR $1E85
          !byte $80         ;dummy
          !byte $08,$CE,$CF,$CD,$CF,$CE,$C9,$C3,$CF
-                           ;NOMONICO
+                           ;"NOMONICO"
 +        bcc   +
          ldy   #19
          jsr   SearchTrack


### PR DESCRIPTION
`id/inspect0.a`: The other JSRs in this list have a single space between their `;` and description, so I added one for `Apple Pascal`.

`patchers/d5d5f7.a`: The 2015-03-27 writeup says this is a lowercase `'n`, but in the patcher it's uppercased.

`patchers/memory.config.a`: The capitalized PRODOS seems out of place here.

`patchers/sierra.a`: I got confused wondering what op code NOMONICO was, until I realized that it was a literal string. Elsewhere in the various codes the literal strings are double-quoted.