### PR TITLE
Properly fix building on case-sensitive OSes, make makefile more closer to winmake.bat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,36 +17,35 @@ ACME=acme
 CADIUS=cadius
 # https://bitbucket.org/magli143/exomizer/wiki/Home
 # requires Exomizer 3.0 or later
-EXOMIZER=exomizer raw -q -P23
+EXOMIZER=exomizer
 
 BUILDDISK=build/passport
 
 asm:
 	mkdir -p build
 	cd src/mods && $(ACME) universalrwts.a
-	$(EXOMIZER) build/universalrwts.bin -o build/universalrwts.tmp
-	printf "\xB8\x00" | cat - build/universalrwts.tmp > build/universalrwts.pak
+	$(EXOMIZER) mem -lnone -q -P23 -f build/universalrwts.bin@0xb800 -o build/universalrwts.pak
 	cd src/mods && $(ACME) -r ../../build/t00only.lst t00only.a
-	$(EXOMIZER) build/t00only.bin -o build/t00only.tmp
-	printf "\x20\x00" | cat - build/t00only.tmp > build/t00only.pak
-	cd src && $(ACME) -r ../build/passport.lst -o ../build/passport.tmp -DFORWARD_DECRUNCHING=1 passport.a 2> ../build/relbase.log
-	cd src && $(ACME) -DRELBASE=`cat ../build/relbase.log | grep "RELBASE =" | cut -d"=" -f2 | cut -d"(" -f2 | cut -d")" -f1` -DFORWARD_DECRUNCHING=1 passport.a 2> ../build/vars.log
-	grep "ThisSlot=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
-	grep "PrintByID=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
-	grep "WaitForKey=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
-	grep "CleanExit=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
-	grep "OpenFile=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
-	grep "ReadFile=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
-	grep "CloseFile=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
-	grep "GetVolumeName=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
-	grep "GetVolumeInfo=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
-	grep "PREFSVER=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
-	grep "PREFSFILE=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
-	grep "SLOT=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
-	grep "DRIVE=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
-	grep "MainMenu=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
-	grep "CheckCache=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
-	$(EXOMIZER) -b build/passport.tmp -o build/passport.pak
+	$(EXOMIZER) mem -lnone -q -P23 -f build/t00only.bin@0x2000 -o build/t00only.pak
+	echo > build/vars.a
+	cd src && $(ACME) -r ../build/passport.lst -DFORWARD_DECRUNCHING=1 passport.a 2> ../build/relbase.log
+	cd src && $(ACME) -r ../build/passport.lst -DRELBASE=`cat ../build/relbase.log | grep "RELBASE =" | cut -d"=" -f2 | cut -d"(" -f2 | cut -d")" -f1` -DFORWARD_DECRUNCHING=1 passport.a 2> ../build/vars.log
+	grep -m1 "ThisSlot=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
+	grep -m1 "PrintByID=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
+	grep -m1 "WaitForKey=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
+	grep -m1 "CleanExit=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
+	grep -m1 "OpenFile=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
+	grep -m1 "ReadFile=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
+	grep -m1 "CloseFile=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
+	grep -m1 "GetVolumeName=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
+	grep -m1 "GetVolumeInfo=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
+	grep -m1 "PREFSVER=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
+	grep -m1 "PREFSFILE=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
+	grep -m1 "SLOT=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
+	grep -m1 "DRIVE=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
+	grep -m1 "MainMenu=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
+	grep -m1 "CheckCache=" build/vars.log | cut -d":" -f3 | cut -d"(" -f1 >> build/vars.a
+	$(EXOMIZER) raw -q -P23 -b build/passport.tmp -o build/passport.pak
 	cd src && $(ACME) -DFORWARD_DECRUNCHING=0 wrapper.a
 	cp res/work.po "$(BUILDDISK)".po
 	cp res/_FileInformation.txt build/

--- a/src/passport.a
+++ b/src/passport.a
@@ -37,7 +37,7 @@
 VERBOSE  = $00       ; set to $01 to display API label addresses
 }
 
-!to "../build/PASSPORT.TMP",plain
+!to "../build/passport.tmp",plain
 !ct "lcase.ct"
 
 Relocatable


### PR DESCRIPTION
My previous PR (#109) didn't actually fix the issue and acme would give a warning that was hidden by the redirected stderr